### PR TITLE
add pickle writer

### DIFF
--- a/qcodes/ZMQ_learning/measurer.py
+++ b/qcodes/ZMQ_learning/measurer.py
@@ -35,7 +35,8 @@ class Measurer:
     _ports_to_try: int = 10  # number of ports to try to bind to in init
 
     def __init__(self, start_port: int,
-                 suicide_timeout: Optional[float]=None) -> None:
+                 suicide_timeout: Optional[float]=None,
+                 file_format: Optional[str]=None) -> None:
 
         # ZMQ related variables
         self._ctx = zmq.Context()
@@ -48,6 +49,7 @@ class Measurer:
         # Run related variables
         self._current_chunk_number: int = 0
         self._guid = f"{'0'*8}-{'0'*4}-{'0'*4}-{'0'*4}-{'0'*12}"
+        self._file_format = file_format
 
         self._timeout = suicide_timeout or DEFAULT_SUICIDE_TIMEOUT
         self._last_write = perf_counter() - self._timeout - 1
@@ -141,7 +143,8 @@ class Measurer:
     def _spawn_writer(self) -> None:
         cmd = ["python", self._path_to_writer,
                f"{self._push_port}",
-               f"{self._req_port}"]
+               f"{self._req_port}",
+               f"{self._file_format}"]
 
         t = time()
         # extract 'sub' - seconds
@@ -227,4 +230,3 @@ class Measurer:
     @property
     def req_port(self):
         return self._req_port
-

--- a/qcodes/ZMQ_learning/tests/test_integration_measurer_writer.py
+++ b/qcodes/ZMQ_learning/tests/test_integration_measurer_writer.py
@@ -1,55 +1,63 @@
 import os
 from subprocess import TimeoutExpired
+import pickle
 
-from qcodes.ZMQ_learning.file_writers import GnuplotWriter, \
-    WRITE_ROW_ARTIFICIAL_SLEEP
+from qcodes.ZMQ_learning.file_writers import (
+    GnuplotWriter, PickleWriter, WRITE_ROW_ARTIFICIAL_SLEEP)
 from qcodes.ZMQ_learning.measurer import Measurer, WRITER_SPAWN_SLEEP_TIME
 from qcodes.ZMQ_learning.common_config import DEFAULT_SUICIDE_TIMEOUT
-from qcodes.ZMQ_learning.writer import DIR_FOR_DATAFILE, \
-    WRITER_THREAD_WRAP_UP_TIMEOUT
+from qcodes.ZMQ_learning.writer import (
+    DIR_FOR_DATAFILE, WRITER_THREAD_WRAP_UP_TIMEOUT, DATA_FILE_WRITERS_MAP)
+import qcodes.ZMQ_learning.writer as writer_module
 
 
 DEFAULT_STARTING_PORT = 6000
 
 
 def test_good_weather():
-    m = Measurer(DEFAULT_STARTING_PORT)
+    for writer_name, writer in DATA_FILE_WRITERS_MAP.items():
+        m = Measurer(DEFAULT_STARTING_PORT, file_format=writer_name)
 
-    # asserts after initialization
-    assert DEFAULT_SUICIDE_TIMEOUT == m._timeout
-    assert '00000000-0000-0000-0000-000000000000' == m.guid
+        # asserts after initialization
+        assert DEFAULT_SUICIDE_TIMEOUT == m._timeout
+        assert '00000000-0000-0000-0000-000000000000' == m.guid
 
-    # start run, after this we are supposed to call 'add_result'
-    m.start_run()
-    guid = m.guid
-    assert 0 == m._current_chunk_number
+        # start run, after this we are supposed to call 'add_result'
+        m.start_run()
+        guid = m.guid
+        assert 0 == m._current_chunk_number
 
-    # add some results in a loop
-    vals = [0, 1, 5, 6, 8]
-    p_name = 'param'
-    for val in vals:
-        m.add_result(((p_name, val),))
+        # add some results in a loop
+        vals = [0, 1, 5, 6, 8]
+        p_name = 'param'
+        for val in vals:
+            m.add_result(((p_name, val),))
 
-    # sleep in order to wait for writer to complete
-    max_time_to_wait = WRITER_SPAWN_SLEEP_TIME \
-                       + len(vals) * (WRITE_ROW_ARTIFICIAL_SLEEP + 0.1) \
-                       + WRITER_THREAD_WRAP_UP_TIMEOUT \
-                       + m.timeout
-    try:
-        m._current_writer_process.wait(timeout=max_time_to_wait)
-    except TimeoutExpired as e:
-        m._current_writer_process.kill()
-        raise e
+        # sleep in order to wait for writer to complete
+        max_time_to_wait = WRITER_SPAWN_SLEEP_TIME \
+                        + len(vals) * (WRITE_ROW_ARTIFICIAL_SLEEP + 0.1) \
+                        + WRITER_THREAD_WRAP_UP_TIMEOUT \
+                        + m.timeout
+        try:
+            m._current_writer_process.wait(timeout=max_time_to_wait)
+        except TimeoutExpired as e:
+            m._current_writer_process.kill()
+            raise e
 
-    # find the written file
-    datafile = os.path.join(
-        DIR_FOR_DATAFILE,
-        guid + GnuplotWriter._extension
-    )
-    assert os.path.exists(datafile), f"{datafile!r} is expected to exist!"
+        # find the written file
+        datafile = os.path.join(
+            DIR_FOR_DATAFILE,
+            guid + writer._extension
+        )
+        assert os.path.exists(datafile), f"{datafile!r} is expected to exist!"
 
-    # assert the data file contents
-    vals_str = '\n'.join([str(val) for val in vals])
-    expected_content = f"{p_name}\n{vals_str}\n"
-    file_content = open(datafile, 'r').read()
-    assert expected_content == file_content
+        if writer is GnuplotWriter:
+            # assert the data file contents
+            vals_str = '\n'.join([str(val) for val in vals])
+            expected_content = f"{p_name}\n{vals_str}\n"
+            file_content = open(datafile, 'r').read()
+            assert expected_content == file_content
+        elif writer is PickleWriter:
+            with open(datafile, 'rb') as f:
+                for v in vals:
+                    assert pickle.load(f) == (('param', v),)

--- a/qcodes/ZMQ_learning/tests/test_integration_measurer_writer.py
+++ b/qcodes/ZMQ_learning/tests/test_integration_measurer_writer.py
@@ -3,61 +3,81 @@ from subprocess import TimeoutExpired
 import pickle
 
 from qcodes.ZMQ_learning.file_writers import (
-    GnuplotWriter, PickleWriter, WRITE_ROW_ARTIFICIAL_SLEEP)
+    WRITE_ROW_ARTIFICIAL_SLEEP)
 from qcodes.ZMQ_learning.measurer import Measurer, WRITER_SPAWN_SLEEP_TIME
 from qcodes.ZMQ_learning.common_config import DEFAULT_SUICIDE_TIMEOUT
 from qcodes.ZMQ_learning.writer import (
     DIR_FOR_DATAFILE, WRITER_THREAD_WRAP_UP_TIMEOUT, DATA_FILE_WRITERS_MAP)
-import qcodes.ZMQ_learning.writer as writer_module
 
 
 DEFAULT_STARTING_PORT = 6000
 
 
-def test_good_weather():
-    for writer_name, writer in DATA_FILE_WRITERS_MAP.items():
-        m = Measurer(DEFAULT_STARTING_PORT, file_format=writer_name)
+def try_to_wait(n_vals, measurer):
+    # sleep in order to wait for writer to complete
+    max_time_to_wait = WRITER_SPAWN_SLEEP_TIME \
+        + n_vals * (WRITE_ROW_ARTIFICIAL_SLEEP + 0.1) \
+        + WRITER_THREAD_WRAP_UP_TIMEOUT \
+        + measurer.timeout
+    try:
+        measurer._current_writer_process.wait(timeout=max_time_to_wait)
+    except TimeoutExpired as e:
+        measurer._current_writer_process.kill()
+        raise e
 
-        # asserts after initialization
-        assert DEFAULT_SUICIDE_TIMEOUT == m._timeout
-        assert '00000000-0000-0000-0000-000000000000' == m.guid
 
-        # start run, after this we are supposed to call 'add_result'
-        m.start_run()
-        guid = m.guid
-        assert 0 == m._current_chunk_number
+def add_weather_data(measurer):
+    vals = [0, 1, 5, 6, 8]
+    p_name = 'param'
+    weather_data = [ ((p_name, val),) for val in vals ]
+    for t in weather_data:
+        measurer.add_result(t)
+    return weather_data
 
-        # add some results in a loop
-        vals = [0, 1, 5, 6, 8]
-        p_name = 'param'
-        for val in vals:
-            m.add_result(((p_name, val),))
 
-        # sleep in order to wait for writer to complete
-        max_time_to_wait = WRITER_SPAWN_SLEEP_TIME \
-                        + len(vals) * (WRITE_ROW_ARTIFICIAL_SLEEP + 0.1) \
-                        + WRITER_THREAD_WRAP_UP_TIMEOUT \
-                        + m.timeout
-        try:
-            m._current_writer_process.wait(timeout=max_time_to_wait)
-        except TimeoutExpired as e:
-            m._current_writer_process.kill()
-            raise e
+def get_data_file_path(measurer):
+    guid = measurer.guid
+    writer = DATA_FILE_WRITERS_MAP[measurer._file_format]
+    # find the written file
+    datafile = os.path.join(
+        DIR_FOR_DATAFILE,
+        guid + writer._extension
+    )
+    assert os.path.exists(datafile), f"{datafile!r} is expected to exist!"
+    return datafile
 
-        # find the written file
-        datafile = os.path.join(
-            DIR_FOR_DATAFILE,
-            guid + writer._extension
-        )
-        assert os.path.exists(datafile), f"{datafile!r} is expected to exist!"
 
-        if writer is GnuplotWriter:
-            # assert the data file contents
-            vals_str = '\n'.join([str(val) for val in vals])
-            expected_content = f"{p_name}\n{vals_str}\n"
-            file_content = open(datafile, 'r').read()
-            assert expected_content == file_content
-        elif writer is PickleWriter:
-            with open(datafile, 'rb') as f:
-                for v in vals:
-                    assert pickle.load(f) == (('param', v),)
+def test_measurer_initialization():
+    m = Measurer(DEFAULT_STARTING_PORT)
+
+    # asserts after initialization
+    assert DEFAULT_SUICIDE_TIMEOUT == m._timeout
+    assert '00000000-0000-0000-0000-000000000000' == m.guid
+
+    m.start_run()
+    assert 0 == m._current_chunk_number
+
+
+def test_gnuplot_writer():
+    m = Measurer(DEFAULT_STARTING_PORT,  file_format='GNUPLOT')
+    m.start_run()
+    weather_data = add_weather_data(m)
+    try_to_wait(len(weather_data), m)
+    datafile = get_data_file_path(m)
+
+    # assert the data file contents
+    vals_str = '\n'.join([str(t[0][1]) for t in weather_data])
+    expected_content = f"{weather_data[0][0][0]}\n{vals_str}\n"
+    file_content = open(datafile, 'r').read()
+    assert expected_content == file_content
+
+
+def test_pickle_writer():
+    m = Measurer(DEFAULT_STARTING_PORT, file_format='PICKLE')
+    m.start_run()
+    weather_data = add_weather_data(m)
+    try_to_wait(len(weather_data), m)
+    datafile = get_data_file_path(m)
+    with open(datafile, 'rb') as f:
+        for t in weather_data:
+            assert pickle.load(f) == t

--- a/qcodes/ZMQ_learning/writer.py
+++ b/qcodes/ZMQ_learning/writer.py
@@ -12,7 +12,7 @@ from threading import Thread, Lock
 import zmq
 from zmq.sugar.socket import Socket
 
-from qcodes.ZMQ_learning.file_writers import GnuplotWriter
+from qcodes.ZMQ_learning.file_writers import GnuplotWriter, PickleWriter
 from qcodes.ZMQ_learning.common_config import DEFAULT_SUICIDE_TIMEOUT, ADDRESS,\
     TRANSPORT_PROTOCOL
 
@@ -20,8 +20,9 @@ from qcodes.ZMQ_learning.common_config import DEFAULT_SUICIDE_TIMEOUT, ADDRESS,\
 DEFAULT_PING_TIMEOUT = DEFAULT_SUICIDE_TIMEOUT
 WRITER_THREAD_WRAP_UP_TIMEOUT = 10  # set to None in order to wait forever
 
-DATA_FILE_WRITERS_MAP = {'GNUPLOT': GnuplotWriter}
-DEFAULT_FILE_MODE = list(DATA_FILE_WRITERS_MAP.keys())[0]
+DATA_FILE_WRITERS_MAP = {'GNUPLOT': GnuplotWriter,
+                         'PICKLE': PickleWriter}
+DEFAULT_FILE_MODE = list(DATA_FILE_WRITERS_MAP.keys())[1]
 
 DIR_FOR_DATAFILE = PurePath(os.path.realpath(__file__)).parent
 


### PR DESCRIPTION
This is a binary writer for the messages using the the inbuilt pickle module. It sticks to the originally suggested ABC.

As mentioned on slack, for efficient binary message writing we should:
- implement `add_results` (with an 's') with the goal of adding multiple rows in one go


and lift assumptions of the ABC that
- there is a header
- we are only writing to one file at at time
- we are writing in rows